### PR TITLE
fix vertical centering issue on text span

### DIFF
--- a/src/css/percircle.css
+++ b/src/css/percircle.css
@@ -200,8 +200,9 @@
   z-index: 1;
   width: 100%;
   top: 50%;
+  top: calc(50% - 0.1em);
+  transform: translateY(-50%);
   height: 1em;
-  margin-top: -0.5em;
   font-size: 0.2em;
   color: #cccccc;
   display: block;

--- a/src/css/percircle.css
+++ b/src/css/percircle.css
@@ -239,11 +239,11 @@
   cursor: default;
 }
 .percircle:hover > span {
-  -webkit-transform: scale(1.3);
-  -moz-transform: scale(1.3);
-  -ms-transform: scale(1.3);
-  -o-transform: scale(1.3);
-  transform: scale(1.3);
+  -webkit-transform: scale(1.3) translateY(-50%);
+  -moz-transform: scale(1.3) translateY(-50%);
+  -ms-transform: scale(1.3) translateY(-50%);
+  -o-transform: scale(1.3) translateY(-50%);
+  transform: scale(1.3) translateY(-50%);
   color: #307bbb;
 }
 .percircle:hover:after {


### PR DESCRIPTION
Test span in the middle was a little bit low, so it now takes into account the bottom margin of its parent